### PR TITLE
Added partial refresh support to Waveshare 2.7 inch V2

### DIFF
--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -36,6 +36,9 @@ class Display(View):
 
     def is_waveshare_v2(self):
         return self._implementation.name == 'waveshare_2'
+    
+    def is_waveshare_v3(self):
+        return self._implementation.name == 'waveshare_3'
 
     def is_waveshare27inch(self):
         return 'waveshare27inch' in self._implementation.name
@@ -72,6 +75,12 @@ class Display(View):
 
     def is_waveshare213bc(self):
         return self._implementation.name == 'waveshare213bc'
+    
+    def is_waveshare213inb_v4(self):
+        return self._implementation.name == 'waveshare213inb_v4'
+
+    def is_waveshare35lcd(self):
+        return self._implementation.name == 'waveshare35lcd'
 
     def is_spotpear24inch(self):
         return self._implementation.name == 'spotpear24inch'

--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -37,14 +37,14 @@ class Display(View):
     def is_waveshare_v2(self):
         return self._implementation.name == 'waveshare_2'
 
-    def is_waveshare_v3(self):
-        return self._implementation.name == 'waveshare_3'
-
     def is_waveshare27inch(self):
-        return self._implementation.name == 'waveshare27inch'
+        return 'waveshare27inch' in self._implementation.name
 
     def is_waveshare27inch_v2(self):
         return self._implementation.name == 'waveshare27inch_v2'
+
+    def is_waveshare27inch_v2Partial(self):
+        return self._implementation.name == 'waveshare27inch_v2Partial'
 
     def is_waveshare29inch(self):
         return self._implementation.name == 'waveshare29inch'
@@ -72,12 +72,6 @@ class Display(View):
 
     def is_waveshare213bc(self):
         return self._implementation.name == 'waveshare213bc'
-
-    def is_waveshare213inb_v4(self):
-        return self._implementation.name == 'waveshare213inb_v4'
-
-    def is_waveshare35lcd(self):
-        return self._implementation.name == 'waveshare35lcd'
 
     def is_spotpear24inch(self):
         return self._implementation.name == 'spotpear24inch'

--- a/pwnagotchi/ui/hw/waveshare27inch_v2Partial.py
+++ b/pwnagotchi/ui/hw/waveshare27inch_v2Partial.py
@@ -1,0 +1,60 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class Waveshare27inch_v2Partial(DisplayImpl):
+    def __init__(self, config):
+        super(Waveshare27inch_v2Partial, self).__init__(config, 'waveshare27inch_v2Partial')
+        self._display = None
+        self.counter = 0
+
+    def layout(self):
+        fonts.setup(10, 9, 10, 35, 25, 9)
+        self._layout['width'] = 264
+        self._layout['height'] = 176
+        self._layout['face'] = (66, 27)
+        self._layout['name'] = (5, 73)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (28, 0)
+        self._layout['uptime'] = (199, 0)
+        self._layout['line1'] = [0, 14, 264, 14]
+        self._layout['line2'] = [0, 162, 264, 162]
+        self._layout['friend_face'] = (0, 146)
+        self._layout['friend_name'] = (40, 146)
+        self._layout['shakes'] = (0, 163)
+        self._layout['mode'] = (239, 163)
+        self._layout['status'] = {
+            'pos': (38, 93),
+            'font': fonts.status_font(fonts.Medium),
+            'max': 40
+        }
+        return self._layout
+
+
+
+    def initialize(self):
+        logging.info("initializing waveshare v2 2.7 inch display with partial rendering")
+        from pwnagotchi.ui.hw.libs.waveshare.v27inch_v2.epd2in7_V2 import EPD
+        self._display = EPD()
+        self._display.init()
+        self._display.Clear()
+
+
+    def render(self, canvas):
+        buf = self._display.getbuffer(canvas)
+
+        if self.counter == 0:
+            self._display.display(buf)
+        else:
+            self._display.display_Partial(buf, 0, 0, 176, 264)
+
+        if self.counter == 25:
+            self.counter = 0
+        else:
+            self.counter += 1
+
+
+    def clear(self):
+        pass

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -248,14 +248,14 @@ def load_config(args):
     elif config['ui']['display']['type'] in ('ws_2', 'ws2', 'waveshare_2', 'waveshare2'):
         config['ui']['display']['type'] = 'waveshare_2'
 
-    elif config['ui']['display']['type'] in ('ws_3', 'ws3', 'waveshare_3', 'waveshare3'):
-        config['ui']['display']['type'] = 'waveshare_3'
-
     elif config['ui']['display']['type'] in ('ws_27inch', 'ws27inch', 'waveshare_27inch', 'waveshare27inch'):
         config['ui']['display']['type'] = 'waveshare27inch'
 
     elif config['ui']['display']['type'] in ('ws_27inch_v2', 'ws27inch_v2', 'waveshare_27inch_v2', 'waveshare27inch_v2'):
         config['ui']['display']['type'] = 'waveshare27inch_v2'
+
+    elif config['ui']['display']['type'] in ('ws_27inch_v2Partial', 'ws27inch_v2Partial', 'waveshare_27inch_v2Partial', 'waveshare27inch_v2Partial'):
+        config['ui']['display']['type'] = 'waveshare27inch_v2Partial'
 
     elif config['ui']['display']['type'] in ('ws_29inch', 'ws29inch', 'waveshare_29inch', 'waveshare29inch'):
         config['ui']['display']['type'] = 'waveshare29inch'
@@ -280,12 +280,6 @@ def load_config(args):
 
     elif config['ui']['display']['type'] in ('ws_213bc', 'ws213bc', 'waveshare_213bc', 'waveshare213bc'):
         config['ui']['display']['type'] = 'waveshare213bc'
-
-    elif config['ui']['display']['type'] in ('ws_213bv4', 'ws213bv4', 'waveshare_213bv4', 'waveshare213inb_v4'):
-        config['ui']['display']['type'] = 'waveshare213inb_v4'
-
-    elif config['ui']['display']['type'] in ('waveshare35lcd'):
-        config['ui']['display']['type'] = 'waveshare35lcd'
 
     elif config['ui']['display']['type'] in ('spotpear24inch'):
         config['ui']['display']['type'] = 'spotpear24inch'

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -247,6 +247,9 @@ def load_config(args):
 
     elif config['ui']['display']['type'] in ('ws_2', 'ws2', 'waveshare_2', 'waveshare2'):
         config['ui']['display']['type'] = 'waveshare_2'
+        
+    elif config['ui']['display']['type'] in ('ws_3', 'ws3', 'waveshare_3', 'waveshare3'):
+        config['ui']['display']['type'] = 'waveshare_3'
 
     elif config['ui']['display']['type'] in ('ws_27inch', 'ws27inch', 'waveshare_27inch', 'waveshare27inch'):
         config['ui']['display']['type'] = 'waveshare27inch'
@@ -280,6 +283,12 @@ def load_config(args):
 
     elif config['ui']['display']['type'] in ('ws_213bc', 'ws213bc', 'waveshare_213bc', 'waveshare213bc'):
         config['ui']['display']['type'] = 'waveshare213bc'
+        
+    elif config['ui']['display']['type'] in ('ws_213bv4', 'ws213bv4', 'waveshare_213bv4', 'waveshare213inb_v4'):
+        config['ui']['display']['type'] = 'waveshare213inb_v4'
+
+    elif config['ui']['display']['type'] in ('waveshare35lcd'):
+        config['ui']['display']['type'] = 'waveshare35lcd'
 
     elif config['ui']['display']['type'] in ('spotpear24inch'):
         config['ui']['display']['type'] = 'spotpear24inch'


### PR DESCRIPTION
Hi! I saw your PR on evilsocket/pwnagotchi to add support to the **Waveshare 2.7 inch V2** display and modified it with https://github.com/daniilprohorov/pwnagotchi @daniilprohorov 's fork for 2.7 inch V1 partial refresh as a reference.

This change also ensures that plugins like memtemp recognize the display as a **2.7 inch V1** and don't lose their preconfigured position settings

I would greatly appeciate your pulling my changes so that we can hopefully improve the display support for the main pwnagotchi repo!